### PR TITLE
Configure LiDAR support

### DIFF
--- a/App/SceneDelegate.swift
+++ b/App/SceneDelegate.swift
@@ -1,3 +1,4 @@
+import ARKit
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -12,6 +13,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = scene as? UIWindowScene else { return }
 
         window = UIWindow(windowScene: windowScene)
+
+        let supportLiDAR = ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh)
+        UserDefaults.standard.setValue(supportLiDAR, forKey: "supportLidar")
 
         if let window = window {
             let appModule = AppModule()

--- a/RoomScan/Sources/RoomScan/Landing/Components/NotificationView/NotificationView+Design.swift
+++ b/RoomScan/Sources/RoomScan/Landing/Components/NotificationView/NotificationView+Design.swift
@@ -1,0 +1,59 @@
+import UIKit
+import SnapKit
+import CoreUi
+
+extension NotificationView {
+
+    func buildViews() {
+        createViews()
+        styleViews()
+        defineLayoutForViews()
+    }
+
+    func createViews() {
+        stackView = UIStackView()
+        addSubview(stackView)
+
+        labelOne = UILabel()
+        stackView.addArrangedSubview(labelOne)
+
+        labelTwo = UILabel()
+        stackView.addArrangedSubview(labelTwo)
+
+        labelThree = UILabel()
+        stackView.addArrangedSubview(labelThree)
+    }
+
+    func styleViews() {
+        backgroundColor = .beige
+        roundAllCorners(withRadius: cornerRadius)
+
+        stackView.axis = .vertical
+        stackView.spacing = 12
+
+        labelOne.font = UIFont(with: .futura, size: 16)
+        labelOne.text = LocalizableStrings.noLidarSupportPartOne.localized
+        labelOne.textColor = .black
+        labelOne.textAlignment = .center
+        labelOne.numberOfLines = 0
+
+        labelTwo.font = UIFont(with: .futura, size: 16)
+        labelTwo.text = LocalizableStrings.noLidarSupportPartTwo.localized
+        labelTwo.textColor = .black
+        labelTwo.textAlignment = .center
+        labelTwo.numberOfLines = 0
+
+        labelThree.font = UIFont(with: .futura, size: 20)
+        labelThree.text = LocalizableStrings.noLidarSupportPartThree.localized
+        labelThree.textColor = .black
+        labelThree.textAlignment = .center
+        labelThree.numberOfLines = 0
+    }
+
+    func defineLayoutForViews() {
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(defaultPadding * 2)
+        }
+    }
+
+}

--- a/RoomScan/Sources/RoomScan/Landing/Components/NotificationView/NotificationView.swift
+++ b/RoomScan/Sources/RoomScan/Landing/Components/NotificationView/NotificationView.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+class NotificationView: UIView {
+
+    let defaultPadding: CGFloat = 8
+    let cornerRadius: CGFloat = .doublePadding
+
+    var stackView: UIStackView!
+    var labelOne: UILabel!
+    var labelTwo: UILabel!
+    var labelThree: UILabel!
+
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        buildViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/RoomScan/Sources/RoomScan/Landing/RoomScanLandingViewController+Design.swift
+++ b/RoomScan/Sources/RoomScan/Landing/RoomScanLandingViewController+Design.swift
@@ -26,6 +26,9 @@ extension RoomScanLandingViewController {
         startScanView = UIImageView()
         view.addSubview(startScanView)
 
+        notificationView = NotificationView()
+        view.addSubview(notificationView)
+
         bottomDivider = DividerView()
         view.addSubview(bottomDivider)
 
@@ -53,11 +56,17 @@ extension RoomScanLandingViewController {
 
         startScanView.image = UIImage(named: BundleImage.arrowDown.rawValue, in: .module, with: nil)
         startScanView.contentMode = .scaleAspectFit
+        startScanView.isHidden = !supportsLidar
 
         startRoomScanButton.setTitle(CoreUi.LocalizableStrings.start.localized, for: .normal)
         startRoomScanButton.setTitleColor(.white, for: .normal)
         startRoomScanButton.backgroundColor = .black
         startRoomScanButton.roundAllCorners(withRadius: cornerRadius)
+        startRoomScanButton.isHidden = !supportsLidar
+
+        notificationView.isHidden = supportsLidar
+
+        bottomDivider.isHidden = !supportsLidar
 
         loadingIndicator.isHidden = true
 
@@ -85,6 +94,11 @@ extension RoomScanLandingViewController {
             $0.size.equalTo(arrowImageSize)
             $0.centerX.equalToSuperview()
             $0.bottom.equalTo(bottomDivider.snp.top)
+        }
+
+        notificationView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(defaultPadding * 4)
+            $0.top.equalTo(topDivider.snp.bottom).offset(defaultPadding * 4)
         }
 
         bottomDivider.snp.makeConstraints {

--- a/RoomScan/Sources/RoomScan/Landing/RoomScanLandingViewController.swift
+++ b/RoomScan/Sources/RoomScan/Landing/RoomScanLandingViewController.swift
@@ -13,11 +13,13 @@ public class RoomScanLandingViewController: UIViewController {
     let navBarHeight: CGFloat = 60
     let startButtonHeight: CGFloat = 60
     let arrowImageSize = CGSize(width: 150, height: 150)
+    let supportsLidar: Bool = UserDefaults.standard.bool(forKey: "supportLidar")
 
     var navBarView: NavBarView!
     var topDivider: DividerView!
     var collectionView: UICollectionView!
     var startScanView: UIImageView!
+    var notificationView: NotificationView!
     var bottomDivider: DividerView!
     var startRoomScanButton: UIButton!
     var loadingIndicator: UIActivityIndicatorView!
@@ -93,6 +95,8 @@ public class RoomScanLandingViewController: UIViewController {
     }
 
     private func populateView() {
+        guard supportsLidar else { return }
+
         if presenter.roomScanModels.count == 0 {
             collectionView.isHidden = true
             startScanView.isHidden = false

--- a/RoomScan/Sources/RoomScan/Resources/Localization/Localizable.xcstrings
+++ b/RoomScan/Sources/RoomScan/Resources/Localization/Localizable.xcstrings
@@ -1,6 +1,75 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "noLidarSupportPartOne" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leider haben wir festgestellt, dass Ihr Gerät nicht über LiDAR-Sensoren verfügt, die für diese Funktion erforderlich sind."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unfortunatelly, we identified your device doesn't have LiDAR sensors which are required for this feature. "
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nažalost, utvrdili smo da vaš uređaj nema LiDAR senzore koji su potrebni za ovu značajku."
+          }
+        }
+      }
+    },
+    "noLidarSupportPartThree" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippen Sie einfach auf das Symbol oben rechts und wechseln Sie das Modul"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simply tap on the top right icon and switch the module"
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jednostavno pritisnite gornju desnu ikonu i promijenite modul"
+          }
+        }
+      }
+    },
+    "noLidarSupportPartTwo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aber keine Sorge, Sie können das andere Modul der App weiterhin nutzen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "But don't worry, you can still use the other module of the app. "
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ali ne brinite, još uvijek možete koristiti drugi modul aplikacije."
+          }
+        }
+      }
+    },
     "scanTheRoom" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/RoomScan/Sources/RoomScan/Resources/Localization/LocalizableStrings.swift
+++ b/RoomScan/Sources/RoomScan/Resources/Localization/LocalizableStrings.swift
@@ -3,6 +3,9 @@ import Core
 enum LocalizableStrings: String {
 
     case scanTheRoom
+    case noLidarSupportPartOne
+    case noLidarSupportPartTwo
+    case noLidarSupportPartThree
 
     var localized: String {
         rawValue.localize(bundle: .module)


### PR DESCRIPTION
### PR Type
✨ Feature

### Short description
Room scan module is not possible to use on devices without LiDAR sensors.

### Proposed solution
Check for LiDAR support on start of the app and write that info in UserDefaults.

If false is written in UserDefaults - show error description and disable all action buttons except the one for switching the module back to Add virtual object module.

### Before screenshot or video

https://github.com/amarkotic/RoomDecor/assets/40775323/9a062127-b1e5-4a6e-bbe6-3be6d1e9adaf


### After screenshot or video

![after](https://github.com/amarkotic/RoomDecor/assets/40775323/c3fa1234-f680-4ae5-a099-4310a0754fc2)
