### PR TITLE
Initial screen based on LiDAR support

### DIFF
--- a/App/AppModule.swift
+++ b/App/AppModule.swift
@@ -42,7 +42,7 @@ class AppModule {
     private func registerVirtualObjectViewController(in container: Resolver) {
         container.register { (_, args) -> VirtualObjectViewController in
             let type: VirtualObjectType = args()
-            return VirtualObjectViewController(presenter: container.resolve(args: args))
+            return VirtualObjectViewController(presenter: container.resolve(args: type))
         }
         .scope(.unique)
 

--- a/App/Coordinator/AppRouter.swift
+++ b/App/Coordinator/AppRouter.swift
@@ -16,8 +16,15 @@ class AppRouter:
     private let container: Resolver
 
     private lazy var initialViewController: UIViewController = {
-        let initialViewController: RoomScanLandingViewController = container.resolve(args: false)
-        return initialViewController
+        let supportsLidar: Bool = UserDefaults.standard.bool(forKey: "supportLidar")
+
+        if false {
+            let initialViewController: RoomScanLandingViewController = container.resolve(args: false)
+            return initialViewController
+        } else {
+            let initialViewController: VirtualObjectLandingViewController = container.resolve()
+            return initialViewController
+        }
     }()
 
     init(container: Resolver) {
@@ -37,6 +44,10 @@ class AppRouter:
 
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
+
+        if initialViewController is VirtualObjectLandingViewController {
+            showError(for: .missingLidar)
+        }
     }
 
     func showVirtualObjectLandingViewController() {

--- a/CoreUi/Sources/CoreUi/Components/ErrorView/ErrorType.swift
+++ b/CoreUi/Sources/CoreUi/Components/ErrorView/ErrorType.swift
@@ -5,6 +5,7 @@ public enum ErrorType {
     case roomScanLoad
     case virtualObjectSession
     case virtualObjectLoadObject
+    case missingLidar
 
     var description: String {
         switch self {
@@ -18,6 +19,8 @@ public enum ErrorType {
             LocalizableStrings.virtualObjectSession.localized
         case .virtualObjectLoadObject:
             LocalizableStrings.virtualObjectLoadObject.localized
+        case .missingLidar:
+            LocalizableStrings.missingLidar.localized
         }
     }
 

--- a/CoreUi/Sources/CoreUi/Resources/Strings/Localizable.xcstrings
+++ b/CoreUi/Sources/CoreUi/Resources/Strings/Localizable.xcstrings
@@ -70,6 +70,29 @@
         }
       }
     },
+    "missingLidar" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ihr Gerät verfügt nicht über LiDAR-Sensoren. Das bedeutet, dass Sie nur einen kleinen Teil unserer Funktionen nutzen können."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your device doesn't have LiDAR sensors. That means you can only use a small part of our features. "
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaš uređaj nema LiDAR senzore. To znači da možete koristiti samo mali dio naših funkcija."
+          }
+        }
+      }
+    },
     "moduleSwitchSlideToConfirm" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/CoreUi/Sources/CoreUi/Resources/Strings/LocalizableStrings.swift
+++ b/CoreUi/Sources/CoreUi/Resources/Strings/LocalizableStrings.swift
@@ -10,13 +10,14 @@ public enum LocalizableStrings: String {
     case author
     case confirm
 
-    //Errors
+    // Errors
     case errorTitle
     case roomScanSession
     case roomScanSave
     case roomScanLoad
     case virtualObjectSession
     case virtualObjectLoadObject
+    case missingLidar
 
     public var localized: String {
         rawValue.localize(bundle: .module)

--- a/RoomDecor.xcodeproj/project.pbxproj
+++ b/RoomDecor.xcodeproj/project.pbxproj
@@ -657,7 +657,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoniomarkotic.roomDecor.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -690,7 +690,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoniomarkotic.roomDecor.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoniomarkotic.roomDecor.app.appClip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -757,7 +757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoniomarkotic.roomDecor.app.appClip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
### PR Type
✨ Feature

### Short description
LiDAR sensors are necessary for Room Scan feature. First screen visible on devices without LiDAR was the one they can't use.

### Proposed solution
Decide which module will be initial screen depending on device's LiDAR support. 

### Before screenshot or video

https://github.com/amarkotic/RoomDecor/assets/40775323/c57c0beb-190a-453d-9ce9-148d88e148a9


### After screenshot or video

https://github.com/amarkotic/RoomDecor/assets/40775323/bc40ea5d-b0cf-4c9d-b8b9-aba873575233


